### PR TITLE
Add test to verify dependency importsFix: Add test for dependency installation

### DIFF
--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -1,0 +1,10 @@
+# tests/test_dependency.py
+
+def test_import_dependencies():
+    try:
+        import soundfile
+        import cffi
+        import pycparser
+        import empire_chain
+    except ImportError as e:
+        assert False, f"Import failed: {e}"


### PR DESCRIPTION
This PR adds a test case to ensure that critical dependencies (soundfile, cffi, pycparser, empire_chain) can be imported without issues.

Fixes the problem related to dependency installation on Windows.
