### PR TITLE
feat: Add Conversational Memory to Agent

### DIFF
--- a/empire_chain/cookbooks/memory_chat_example.py
+++ b/empire_chain/cookbooks/memory_chat_example.py
@@ -1,0 +1,23 @@
+from empire_chain.agent.agent import Agent
+from empire_chain.memory.conversation_memory import ConversationBufferMemory
+
+# Create memory instance
+memory = ConversationBufferMemory()
+
+# Create agent with memory
+agent = Agent(memory=memory)
+
+# Register a dummy function
+def get_weather(location: str) -> str:
+    """Get current weather in a location"""
+    return f"The weather in {location} is sunny."
+
+agent.register_function(get_weather)
+
+# Query 1: Explicit location
+out1 = agent.process_query("What's the weather in Mumbai?")
+print("First:", out1)
+
+# Query 2: Implicit context (tests memory)
+out2 = agent.process_query("What about in Delhi?")
+print("Second:", out2)


### PR DESCRIPTION
This PR adds conversational memory support to the Agent class in Empire Chain.

✅ Implemented `ConversationBufferMemory` to track user and agent messages  
✅ Integrated memory into the Agent's prompt generation  
✅ Added `cookbooks/memory_chat_example.py` to demonstrate memory usage  
✅ Successfully tested with both mocked and real Groq LLMs  

This is not related to the current Issue #13 (document chunking), but is a valuable agent enhancement and may support future memory-based features.

Let me know if you'd prefer this as a separate feature branch or issue.

Contributed by @Failureguy94 🚀
